### PR TITLE
Bugfix: Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Local Data
 local_data/
 
+# Python
+*.pyc
+
 # Jupyter
 .ipynb_checkpoints
 *.ipynb

--- a/comp_loinc/build.py
+++ b/comp_loinc/build.py
@@ -27,6 +27,7 @@ except ModuleNotFoundError:
 
 app = typer.Typer(help='CompLOINC. A tool for creating an OWL version of LOINC.')
 PROJECT_DIR = Path(os.path.dirname(__file__)).parent
+ROBOT_BIN_PATH = os.path.join(PROJECT_DIR, 'robot')
 DEFAULTS = {
     'schema_file.parts': os.path.join(PROJECT_DIR, 'model', 'schema', 'part_schema.yaml'),
     'schema_file.codes': os.path.join(PROJECT_DIR, 'model', 'schema', 'code_schema.yaml'),
@@ -126,7 +127,7 @@ def merge_owl(
     TODO: Consider removing the files created from this point each time this code executes e.g. any file with 'merge_*'
     """
     files = [os.path.join(owl_directory, str(x)) for x in os.listdir(owl_directory) if ".owl" in str(x)]
-    subprocess.call(["./robot", "merge", "-i"] + " -i ".join(files).split() + ['-o', output])
+    subprocess.call([ROBOT_BIN_PATH, "merge", "-i"] + " -i ".join(files).split() + ['-o', output])
 
 
 @app.command(name="reason")
@@ -140,8 +141,7 @@ def reason_owl(
     :param merged_owl: Name of the merged OWL file created from the `merge` command.
     :param owl_reasoner: The name of the OWL reasoner to use.
     :param output: str where output will be saved."""
-    call_list = [
-        "./robot", "reason", "-r", owl_reasoner, '-i', f"{merged_owl}", '-o', f"{output}"]
+    call_list = [ROBOT_BIN_PATH, "reason", "-r", owl_reasoner, '-i', f"{merged_owl}", '-o', f"{output}"]
     subprocess.call(call_list)
 
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY = all all-force python-dependencies parts codes composed merge reason
+.PHONY: all all-force python-dependencies parts codes composed merge reason test
 
 
 # Utils
@@ -9,36 +9,36 @@ python-dependencies:
 # Pipeline
 ## 1. Run: Build the part ontology from the intermediate Part Hierarchy files
 data/output/owl_component_files/part_ontology.owl: python-dependencies
-	python comp_loinc/build.py parts --schema-file ./model/schema/part_schema.yaml --part-directory ./data/part_files --output ./data/output/owl_component_files/part_ontology.owl
+	python3 comp_loinc/build.py parts --schema-file ./model/schema/part_schema.yaml --part-directory ./data/part_files --output ./data/output/owl_component_files/part_ontology.owl
 parts: data/output/owl_component_files
 
 ## 2. Run: Build the code classes from the intermediate Part Hierarchy files
 data/output/owl_component_files/code_classes.owl: data/output/owl_component_files/part_ontology.owl
-	python comp_loinc/build.py codes --schema-file ./model/schema/code_schema.yaml --part-directory ./data/part_files --output ./data/output/owl_component_files/code_classes.owl
+	python3 comp_loinc/build.py codes --schema-file ./model/schema/code_schema.yaml --part-directory ./data/part_files --output ./data/output/owl_component_files/code_classes.owl
 codes: parts data/output/owl_component_files
 
 ## 3. Run: Build the composed class axioms for the reasoner to group classes (this is pretty bespoke, and hardcoded at the moment)
 data/output/owl_component_files/composed_component_classes.owl: data/output/owl_component_files/code_classes.owl
-	python comp_loinc/build.py composed --schema-file model/schema/grouping_classes_schema.yaml --composed-classes-data-file ./data/composed_classes_data.yaml --output data/output/composed_component_classes.owl
+	python3 comp_loinc/build.py composed --schema-file model/schema/grouping_classes_schema.yaml --composed-classes-data-file ./data/composed_classes_data.yaml --output data/output/composed_component_classes.owl
 composed: codes data/output/composed_component_classes.owl
 
 ## 4. Run: Merge all of the owl files into single merged ontology
 data/output/merged_loinc.owl: data/output/owl_component_files/composed_component_classes.owl
-	python comp_loinc/build.py merge --owl-directory ./data/output/owl_component_files/ --output ./data/output/merged_loinc.owl
+	python3 comp_loinc/build.py merge --owl-directory ./data/output/owl_component_files/ --output ./data/output/merged_loinc.owl
 merge: composed data/output/merged_loinc.owl
 
 ## 5. Run: the reasoner using elk to create the composed code classes
 data/output/merged_reasoned_loinc.owl: data/output/merged_loinc.owl
-	python comp_loinc/build.py reason --merged-owl ./data/output/merged_loinc.owl --owl-reasoner elk --output ./data/output/merged_reasoned_loinc.owl
+	python3 comp_loinc/build.py reason --merged-owl ./data/output/merged_loinc.owl --owl-reasoner elk --output ./data/output/merged_reasoned_loinc.owl
 reason: merge data/output/merged_reasoned_loinc.owl
 
 ## all: Runs the whole pipeline (1-5). Running `reason` directly will do the same thing, as it depends on all the other steps.
 all: data/output/merged_reasoned_loinc.owl
-	python comp_loinc/build.py all
+	python3 comp_loinc/build.py all
 ## all-force: Runs the pipeline, even if the end result `data/output/merged_reasoned_loinc.owl` already exists.
 all-force:
-	python comp_loinc/build.py all
+	python3 comp_loinc/build.py all
 
 # QC / test
 test:
-	python -m unittest discover -v
+	python3 -m unittest discover -v

--- a/test/test.py
+++ b/test/test.py
@@ -1,20 +1,20 @@
 """Unit tests.
 
 TODO's
- 1. CLI tests
-   - fix order this way?: https://stackoverflow.com/questions/5387299/python-unittest-testcase-execution-order
-   - _1 _2 or _a _b in method name might work
- 2. Python API tests
- 3. CompLoincTest: Anything redundant to remove?
- 4. later: Need to run sequentially? Prob not, but have SequentialTests from pma-api I could re-use
- 5. later: Run from __main__? if so, pma-api has a python api to run tests
- 6. How to test outputs? file size? existence? arbitrary content? md5 match?
+ 1. CLI tests (python api tests done)
+   - Pass interpreter path to subprocess?: https://
+   stackoverflow.com/questions/27592006/having-trouble-running-python-interpreter-as-a-subprocess-using-pythons-subproc
+ 3. minor: CompLoincTest: Anything redundant to remove?
+ 4. later (probably not issue): Need to run sequentially? Prob not, but have SequentialTests from pma-api I could re-use
+ 5. later (probably not issue): Run from __main__? if so, pma-api has a python api to run tests
+ 6. later (test improvements): How to test outputs? file size? existence? arbitrary content? md5 match?
 """
 import os
 import shutil
-import subprocess
 import unittest
 from pathlib import Path
+
+from comp_loinc.build import build_part_ontology, build_codes, build_composed_classes, merge_owl, reason_owl
 
 try:
     from test.config import PROJECT_DIR, TEST_STATIC_DIR
@@ -42,93 +42,192 @@ class StaticFileTests(unittest.TestCase):
         return os.path.join(TEST_STATIC_DIR, test_method_dir, 'output')
 
 
-class CompLoincTests(StaticFileTests):
+# TODO 1: re-enable after I've come up w/ a solotion for (1) defined at top of this file
+# class CompLoincCliTests(StaticFileTests):
+#     """CompLOINC tests"""
+#
+#     # TODO: probably don't need this?
+#     def run_command(self, test_name: str, outfile: str, command_str: str) -> float:
+#         """Run command for test"""
+#         outdir = self.outdir(test_name)
+#         Path(outdir).mkdir(parents=True, exist_ok=True)
+#         outpath = os.path.join(outdir, outfile)
+#         command_str = command_str.format(self.cli_command_base, outpath)
+#         command_list = command_str.split(' ')
+#         # todo: Fix: PermissionError: [Errno 1] Operation not permitted: ...
+#         # if os.path.exists(outpath):
+#         #     os.remove(outpath)
+#         subprocess.run(command_list, cwd=PROJECT_DIR)
+#         size_kb = os.path.getsize(outpath) / 1000
+#         return size_kb
+#
+#     def all(self):
+#         """Wrapper for running all at once."""
+#         self.test_cli_1_parts()
+#         self.test_cli_2_codes()
+#         self.test_cli_3_composed()
+#         self.test_cli_4_merge()
+#         self.test_cli_5_reason()
+#
+#     def test_cli_1_parts(self):
+#         """Test CLI: parts"""
+#         test_name = 'test_cli_1_parts'
+#         outfile = 'part_ontology.owl'
+#         filesize_threshold_kb = 500  # semi-arbitrary for now
+#         command_str = \
+#             '{} parts ' \
+#             '--schema-file ./model/schema/part_schema.yaml ' \
+#             '--part-directory ./data/part_files ' \
+#             '--output {}'
+#
+#         size_kb = self.run_command(test_name, outfile, command_str)
+#         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
+#
+#     def test_cli_2_codes(self):
+#         """Test CLI: codes"""
+#         test_name = 'test_cli_2_codes'
+#         outfile = 'code_classes.owl'
+#         filesize_threshold_kb = 500  # semi-arbitrary for now
+#         command_str = \
+#             '{} codes ' \
+#             '--schema-file ./model/schema/code_schema.yaml ' \
+#             '--part-directory ./data/part_files ' \
+#             '--output {}'
+#
+#         size_kb = self.run_command(test_name, outfile, command_str)
+#         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
+#
+#     def test_cli_3_composed(self):
+#         """Test CLI: composed"""
+#         test_name = 'test_cli_3_composed'
+#         outfile = 'composed_component_classes.owl'
+#         filesize_threshold_kb = 3  # semi-arbitrary for now
+#         command_str = \
+#             '{} composed ' \
+#             '--schema-file ./model/schema/grouping_classes_schema.yaml ' \
+#             '--composed-classes-data-file ./data/composed_classes_data.yaml ' \
+#             '--output {}'
+#
+#         size_kb = self.run_command(test_name, outfile, command_str)
+#         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
+#
+#     def test_cli_4_merge(self):
+#         """Test CLI: merge"""
+#         test_name = 'test_cli_4_merge'
+#         outfile = 'merged_loinc.owl'
+#         filesize_threshold_kb = 500  # semi-arbitrary for now
+#         command_str = \
+#             '{} merge ' \
+#             '--owl-directory ./test/static/test_cli_4_merge/input/ ' \
+#             '--output {}'
+#
+#         # Setup
+#         input_dir = './test/static/test_cli_4_merge/input/'
+#         inputs = [os.path.join(*[TEST_STATIC_DIR] + x) for x in [
+#             ['test_cli_1_parts', 'output', 'part_ontology.owl'],
+#             ['test_cli_2_codes', 'output', 'code_classes.owl'],
+#             ['test_cli_3_composed', 'output', 'composed_component_classes.owl']
+#         ]]
+#         # todo: Fix: PermissionError: [Errno 1] Operation not permitted: './test/static/test_cli_merge/input/'
+#         # if os.path.exists(input_dir):
+#         #     os.remove(input_dir)  # just in case last test failed and something goes wrong in this test
+#         Path(input_dir).mkdir(parents=True, exist_ok=True)
+#         for x in inputs:
+#             shutil.copy(x, input_dir)
+#
+#         # Run test
+#         size_kb = self.run_command(test_name, outfile, command_str)
+#         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
+#
+#         # Tearown
+#         # todo: Fix: PermissionError: [Errno 1] Operation not permitted: './test/static/test_cli_merge/input/'
+#         # os.remove(input_dir)
+#
+#     def test_cli_5_reason(self):
+#         """Test CLI: reason"""
+#         test_name = 'test_cli_5_reason'
+#         outfile = 'merged_reasoned_loinc.owl'
+#         filesize_threshold_kb = 500  # semi-arbitrary for now
+#         command_str = \
+#             '{} reason ' \
+#             '--merged-owl ./test/static/test_cli_4_merge/output/merged_loinc.owl ' \
+#             '--owl-reasoner elk ' \
+#             '--output {}'
+#
+#         size_kb = self.run_command(test_name, outfile, command_str)
+#         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
+
+
+class CompLoincPythonAPITests(StaticFileTests):
     """CompLOINC tests"""
-
-    cli_command_base = 'python comp_loinc/build.py'
-
-    def run_command(self, test_name: str, outfile: str, command_str: str) -> float:
-        """Run command for test"""
-        outdir = self.outdir(test_name)
-        Path(outdir).mkdir(parents=True, exist_ok=True)
-        outpath = os.path.join(outdir, outfile)
-        command_str = command_str.format(self.cli_command_base, outpath)
-        command_list = command_str.split(' ')
-        # todo: Fix: PermissionError: [Errno 1] Operation not permitted: ...
-        # if os.path.exists(outpath):
-        #     os.remove(outpath)
-        subprocess.run(command_list, cwd=PROJECT_DIR)
-        size_kb = os.path.getsize(outpath) / 1000
-        return size_kb
 
     def all(self):
         """Wrapper for running all at once."""
-        self.test_cli_1_parts()
-        self.test_cli_2_codes()
-        self.test_cli_3_composed()
-        self.test_cli_4_merge()
-        self.test_cli_5_reason()
+        self.test_python_api_1_parts()
+        self.test_python_api_2_codes()
+        self.test_python_api_3_composed()
+        self.test_python_api_4_merge()
+        self.test_python_api_5_reason()
 
-    def test_cli_1_parts(self):
-        """Test CLI: parts"""
-        test_name = 'test_cli_1_parts'
+    def test_python_api_1_parts(self):
+        """Test Python API: parts"""
+        test_name = 'test_python_api_1_parts'
         outfile = 'part_ontology.owl'
         filesize_threshold_kb = 500  # semi-arbitrary for now
-        command_str = \
-            '{} parts ' \
-            '--schema-file ./model/schema/part_schema.yaml ' \
-            '--part-directory ./data/part_files ' \
-            '--output {}'
 
-        size_kb = self.run_command(test_name, outfile, command_str)
+        outpath = os.path.join(TEST_STATIC_DIR, test_name, 'output', outfile)
+        Path(os.path.dirname(outpath)).mkdir(parents=True, exist_ok=True)
+        build_part_ontology(
+            schema_file=os.path.join(PROJECT_DIR, 'model', 'schema', 'part_schema.yaml'),
+            part_directory=os.path.join(PROJECT_DIR, 'data', 'part_files'),
+            output=outpath)
+        size_kb = os.path.getsize(outpath) / 1000
         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
 
-    def test_cli_2_codes(self):
-        """Test CLI: codes"""
-        test_name = 'test_cli_2_codes'
+    def test_python_api_2_codes(self):
+        """Test Python API: codes"""
+        test_name = 'test_python_api_2_codes'
         outfile = 'code_classes.owl'
         filesize_threshold_kb = 500  # semi-arbitrary for now
-        command_str = \
-            '{} codes ' \
-            '--schema-file ./model/schema/code_schema.yaml ' \
-            '--part-directory ./data/part_files ' \
-            '--output {}'
 
-        size_kb = self.run_command(test_name, outfile, command_str)
+        outpath = os.path.join(TEST_STATIC_DIR, test_name, 'output', outfile)
+        Path(os.path.dirname(outpath)).mkdir(parents=True, exist_ok=True)
+        build_codes(
+            schema_file=os.path.join(PROJECT_DIR, 'model', 'schema', 'code_schema.yaml'),
+            part_directory=os.path.join(PROJECT_DIR, 'data', 'part_files'),
+            output=outpath)
+        size_kb = os.path.getsize(outpath) / 1000
         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
 
-    def test_cli_3_composed(self):
-        """Test CLI: composed"""
-        test_name = 'test_cli_3_composed'
+    def test_python_api_3_composed(self):
+        """Test Python API: composed"""
+        test_name = 'test_python_api_3_composed'
         outfile = 'composed_component_classes.owl'
         filesize_threshold_kb = 3  # semi-arbitrary for now
-        command_str = \
-            '{} composed ' \
-            '--schema-file ./model/schema/grouping_classes_schema.yaml ' \
-            '--composed-classes-data-file ./data/composed_classes_data.yaml ' \
-            '--output {}'
 
-        size_kb = self.run_command(test_name, outfile, command_str)
+        outpath = os.path.join(TEST_STATIC_DIR, test_name, 'output', outfile)
+        Path(os.path.dirname(outpath)).mkdir(parents=True, exist_ok=True)
+        build_composed_classes(
+            schema_file=os.path.join(PROJECT_DIR, 'model', 'schema', 'grouping_classes_schema.yaml'),
+            composed_classes_data_file=os.path.join(PROJECT_DIR, 'data', 'composed_classes_data.yaml'),
+            output=outpath)
+        size_kb = os.path.getsize(outpath) / 1000
         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
 
-    def test_cli_4_merge(self):
-        """Test CLI: merge"""
-        test_name = 'test_cli_4_merge'
+    def test_python_api_4_merge(self):
+        """Test Python API: merge"""
+        test_name = 'test_python_api_4_merge'
         outfile = 'merged_loinc.owl'
         filesize_threshold_kb = 500  # semi-arbitrary for now
-        command_str = \
-            '{} merge ' \
-            '--owl-directory ./test/static/test_cli_4_merge/input/ ' \
-            '--output {}'
 
         # Setup
-        input_dir = './test/static/test_cli_4_merge/input/'
+        input_dir = os.path.join(TEST_STATIC_DIR, 'test_python_api_4_merge', 'input')
         inputs = [os.path.join(*[TEST_STATIC_DIR] + x) for x in [
-            ['test_cli_1_parts', 'output', 'part_ontology.owl'],
-            ['test_cli_2_codes', 'output', 'code_classes.owl'],
-            ['test_cli_3_composed', 'output', 'composed_component_classes.owl']
+            ['test_python_api_1_parts', 'output', 'part_ontology.owl'],
+            ['test_python_api_2_codes', 'output', 'code_classes.owl'],
+            ['test_python_api_3_composed', 'output', 'composed_component_classes.owl']
         ]]
-        # todo: Fix: PermissionError: [Errno 1] Operation not permitted: './test/static/test_cli_merge/input/'
+        # todo: Fix: PermissionError: [Errno 1] Operation not permitted: './test/static/test_python_api_merge/input/'
         # if os.path.exists(input_dir):
         #     os.remove(input_dir)  # just in case last test failed and something goes wrong in this test
         Path(input_dir).mkdir(parents=True, exist_ok=True)
@@ -136,29 +235,35 @@ class CompLoincTests(StaticFileTests):
             shutil.copy(x, input_dir)
 
         # Run test
-        size_kb = self.run_command(test_name, outfile, command_str)
+        outpath = os.path.join(TEST_STATIC_DIR, test_name, 'output', outfile)
+        Path(os.path.dirname(outpath)).mkdir(parents=True, exist_ok=True)
+        merge_owl(
+            owl_directory=input_dir,
+            output=outpath)
+        size_kb = os.path.getsize(outpath) / 1000
         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
 
         # Tearown
-        # todo: Fix: PermissionError: [Errno 1] Operation not permitted: './test/static/test_cli_merge/input/'
+        # todo: Fix: PermissionError: [Errno 1] Operation not permitted: './test/static/test_python_api_merge/input/'
         # os.remove(input_dir)
 
-    def test_cli_5_reason(self):
-        """Test CLI: reason"""
-        test_name = 'test_cli_5_reason'
+    def test_python_api_5_reason(self):
+        """Test Python API: reason"""
+        test_name = 'test_python_api_5_reason'
         outfile = 'merged_reasoned_loinc.owl'
         filesize_threshold_kb = 500  # semi-arbitrary for now
-        command_str = \
-            '{} reason ' \
-            '--merged-owl ./test/static/test_cli_4_merge/output/merged_loinc.owl ' \
-            '--owl-reasoner elk ' \
-            '--output {}'
 
-        size_kb = self.run_command(test_name, outfile, command_str)
+        outpath = os.path.join(TEST_STATIC_DIR, test_name, 'output', outfile)
+        Path(os.path.dirname(outpath)).mkdir(parents=True, exist_ok=True)
+        reason_owl(
+            merged_owl=os.path.join(TEST_STATIC_DIR, 'test_python_api_4_merge', 'output', 'merged_loinc.owl'),
+            owl_reasoner='elk',
+            output=outpath)
+        size_kb = os.path.getsize(outpath) / 1000
         self.assertGreaterEqual(size_kb, filesize_threshold_kb)
 
 
 # Debugging / development
 DEBUG = False
 if DEBUG:
-    CompLoincTests().all()
+    CompLoincPythonAPITests().all()


### PR DESCRIPTION
Updates
```
- Bugfix: unit tests: Now calls Python API directly instead of CLI. this fixes an issue that we were having with calling a subprocess that could use a different python interpreter than the one that is running the unit tests, resulting in either (a) the wrong python version, or (b) a python interpreter that does not have the packages installed.
- Bugfix: makefile: (i) phony target syntax, (ii) python --> python3
- Bugfix: build.py: robot path is now an absolute path. Solves problem where path did not resol
ve based on where the script was being called from.
```