### PR TITLE
Tests: E2E: Static files & GH action

### DIFF
--- a/test/config.py
+++ b/test/config.py
@@ -5,8 +5,11 @@ from pathlib import Path
 
 TEST_DIR = Path(os.path.dirname(__file__))
 PROJECT_DIR = TEST_DIR.parent
-# TEST_IN_DIR = TEST_DIR / 'input'
-TEST_IN_DIR = PROJECT_DIR / 'output' / 'build-default' / 'fast-run'
+BUILD_CONFIG_PATH = PROJECT_DIR / 'comploinc_config.yaml'
+SUBSET_BUILD_DIR = TEST_DIR / 'input' / 'subset_build'  # Takes input release files (LOINC, SNOMED, etc) and subsects them. Then, a build will be run and outputs of that will be test inputs.
+SUBSET_BUILD_GEN_INPUTS = SUBSET_BUILD_DIR / 'input'  # For subsected release files to be stored
+TEST_IN_DIR_SUBSET = SUBSET_BUILD_DIR / 'output'  # For outputs to be stored after running build on subsected release files
+TEST_IN_DIR_FAST_RUN = PROJECT_DIR / 'output' / 'build-default' / 'fast-run'
 TEST_OUT_DIR = TEST_DIR / 'output'
 TEST_SPARQL_QEURY_DIR = TEST_DIR / 'queries'
 ROBOT_JAR_PATH = PROJECT_DIR / 'robot.jar'

--- a/test/gen_inputs.py
+++ b/test/gen_inputs.py
@@ -1,0 +1,93 @@
+"""Generates subsected inputs to allow for fast testable builds.
+
+
+Takes input release files (LOINC, SNOMED, etc) and subsects them. Then, a build will be run and outputs of that will be
+test inputs.
+
+TODO: add cli
+ - cache option
+ - should be able to subesct or gen test outputs independently
+"""
+from pathlib import Path
+from typing import Dict, List, Union
+
+try:
+    # noinspection PyUnresolvedReferences pycharm_confused_by_test_root
+    from test.config import PROJECT_DIR, TEST_IN_DIR_SUBSET as OUTDIR, BUILD_CONFIG_PATH, SUBSET_BUILD_GEN_INPUTS
+    from loinclib import Configuration
+except ModuleNotFoundError:
+    from config import PROJECT_DIR, TEST_IN_DIR_SUBSET as OUTDIR, BUILD_CONFIG_PATH, SUBSET_BUILD_GEN_INPUTS
+    from loinclib import Configuration
+
+
+# TODO: make dirs if don't exist
+#  - all subset dirs. do that here at top of file, or maybe in each func
+
+
+def run_subsect_build():
+    """For outputs to be stored after running build on subsected release files"""
+    # TODO: TEST_BUILD_CONFIG_PATH instead of BUILD_CONFIG_PATH
+    # TODO: override config.logging.loggers.''.level to 'DEBUG'
+    config_wrapper = Configuration(SUBSET_BUILD_GEN_INPUTS, BUILD_CONFIG_PATH)
+    # TODO: How to pass alternative config path?
+    #  - do i need to?
+    #  - is that a CLI option?
+    #    - if not, a. add one, b. temporarily replace config at root. | 'a' seems much better
+    print()
+
+
+def gen_subsect_config():
+    """Generate a comploinc_config.yaml, but for subsected releases"""
+    # TODO: create file: in subset_build/ prolly
+    #  1. copy from comploinc_config.yaml
+    #  2. recurse vals where startswith loinc_release/, loinc_snomed_release/, loinc_trees/, or snomed_release/
+    #    - change val if to put in new dir
+    #    - write yaml to new location
+    # TODO: input dirs: configure them from subset_build/input/
+    # TODO: output dir
+    print()
+
+
+def _get_input_paths(
+    home_path: Union[str, Path] = SUBSET_BUILD_GEN_INPUTS, config_path: Union[str, Path] = BUILD_CONFIG_PATH
+) -> Dict[str, Union[Path, List[Path]]]:
+    """Get input paths from config"""
+    config_wrapper = Configuration(home_path, config_path)
+    config = config_wrapper.config
+    # todo: Maybe re-use existing build logic for resolving these paths
+    loinc_snomed_release_files: List[Path] = [PROJECT_DIR / x
+        for x in config['loinc_snomed']['release'][config['loinc_snomed']['release']['default']]['files'].values()]
+    snomed_release_files: List[Path] = [PROJECT_DIR / x
+        for x in config['snomed']['release'][config['snomed']['release']['default']]['files'].values()]
+    input_paths: Dict[str, Union[Path, List[Path]]] = {
+        'loinc_release': PROJECT_DIR / config['loinc']['release'][config['loinc']['release']['default']]['path'],
+        'loinc_snomed_release': loinc_snomed_release_files,
+        'loinc_trees': PROJECT_DIR / config['loinc_tree']['release'][config['loinc_tree']['release']['default']]['tree_path'],
+        'snomed_release': snomed_release_files,
+    }
+    # TODO: Create empty dirs for each of the release dirs, into
+    #  - i think they will be stored as attributes in `vonfig`
+    return input_paths
+
+def subsect_releases(use_cache=False):
+    """For subsected release files to be stored"""
+    input_paths: Dict[str, Union[Path, List[Path]]] = _get_input_paths()
+    # TODO: Recurse dirs, find files, and subsect them
+    #  a. preconfigured paths to all inputs  <-- easier at first
+    #    - but then I have to go through and figure out all the files to use. they might be referenced in builder or
+    #    similar classs
+    #  b. just do everything
+    #    - disadvantage is that not all files are input files.
+    #  - how did shahim handle tab vs comma or other delim? Are they all tab?
+    print()
+
+
+def gen_test_inputs():
+    """Generate test inputs"""
+    subsect_releases()
+    gen_subsect_config()
+    run_subsect_build()
+
+
+if __name__ == "__main__":
+    gen_test_inputs()

--- a/test/test.py
+++ b/test/test.py
@@ -18,11 +18,11 @@ import pandas as pd
 
 try:
     # noinspection PyUnresolvedReferences pycharm_confused_by_test_root
-    from test.config import PROJECT_DIR, TEST_IN_DIR, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
+    from test.config import PROJECT_DIR, TEST_IN_DIR_FAST_RUN, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
     # noinspection PyUnresolvedReferences pycharm_confused_by_test_root
     from test.utils import sparql_ask, sparql_select
 except ModuleNotFoundError:
-    from config import PROJECT_DIR, TEST_IN_DIR, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
+    from config import PROJECT_DIR, TEST_IN_DIR_FAST_RUN, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
     from utils import sparql_ask, sparql_select
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -8,16 +8,16 @@ from typing import Union
 import pandas as pd
 
 try:
-    from test.config import ROBOT_JAR_PATH, TEST_IN_DIR, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
+    from test.config import ROBOT_JAR_PATH, TEST_IN_DIR_FAST_RUN, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
 except ModuleNotFoundError:
-    from config import ROBOT_JAR_PATH, TEST_IN_DIR, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
+    from config import ROBOT_JAR_PATH, TEST_IN_DIR_FAST_RUN, TEST_OUT_DIR, TEST_SPARQL_QEURY_DIR
 
 robot_cmd_options = ['robot', ROBOT_JAR_PATH]
 
 
 def _get_paths(onto_filename: str, sparql_filename: str) -> tuple[str, str, str]:
     """Derive paths for test from filenames of inputs"""
-    onto_path: str = TEST_IN_DIR / onto_filename
+    onto_path: str = TEST_IN_DIR_FAST_RUN / onto_filename
     sparql_path: str = TEST_SPARQL_QEURY_DIR / sparql_filename
     outname: str = os.path.splitext(os.path.basename(onto_path))[0] + '_' + \
         os.path.splitext(os.path.basename(sparql_path))[0]


### PR DESCRIPTION
## Changes
- Update: GH action: To use new static inputs
- Add: test/gen_inputs.py: Creates truncated inputs from source release files. The goal of this is to have smaller inputs so that the GH action can run a build quickly in order to run tests fast, for every commit to main or PRs.
