### PR TITLE
TIME_ASPECT --> TIME_ASPCT

### DIFF
--- a/src/comp_loinc/datamodel/comp_loinc.py
+++ b/src/comp_loinc/datamodel/comp_loinc.py
@@ -1,5 +1,5 @@
-# Auto generated from comp_loinc.yaml by pythongen.py version: 0.0.1
-# Generation date: 2024-09-06T14:57:46
+# Auto generated from comp_loinc.yaml by pythongen.py version: 0.9.0
+# Generation date: 2024-10-16T15:55:04
 # Schema: loinc-owl-core-schema
 #
 # id: https://loinc.org/core
@@ -7,11 +7,11 @@
 # license: https://creativecommons.org/publicdomain/zero/1.0/
 
 import dataclasses
+import sys
 import re
 from jsonasobj2 import JsonObj, as_dict
 from typing import Optional, List, Union, Dict, ClassVar, Any
 from dataclasses import dataclass
-from datetime import date, datetime
 from linkml_runtime.linkml_model.meta import (
     EnumDefinition,
     PermissibleValue,
@@ -93,12 +93,12 @@ class Loinc(YAMLRoot):
     class_name: ClassVar[str] = "Loinc"
     class_model_uri: ClassVar[URIRef] = LOINC.Loinc
 
-    codes: Optional[Union[Union[str, LoincTermId], List[Union[str, LoincTermId]]]] = (
-        empty_list()
-    )
-    parts: Optional[Union[Union[str, LoincPartId], List[Union[str, LoincPartId]]]] = (
-        empty_list()
-    )
+    codes: Optional[
+        Union[Union[str, LoincTermId], List[Union[str, LoincTermId]]]
+    ] = empty_list()
+    parts: Optional[
+        Union[Union[str, LoincPartId], List[Union[str, LoincPartId]]]
+    ] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if not isinstance(self.codes, list):
@@ -128,9 +128,9 @@ class Entity(YAMLRoot):
     id: Union[str, EntityId] = None
     entity_label: Optional[str] = None
     entity_description: Optional[str] = None
-    sub_class_of: Optional[Union[Union[str, EntityId], List[Union[str, EntityId]]]] = (
-        empty_list()
-    )
+    sub_class_of: Optional[
+        Union[Union[str, EntityId], List[Union[str, EntityId]]]
+    ] = empty_list()
     equivalent_class: Optional[
         Union[Union[str, EntityId], List[Union[str, EntityId]]]
     ] = empty_list()
@@ -298,16 +298,16 @@ class LoincTerm(LoincEntity):
     supplementary_class: Optional[Union[str, LoincPartId]] = None
     supplementary_category: Optional[Union[str, LoincPartId]] = None
     supplementary_search: Optional[Union[str, LoincPartId]] = None
-    primary_rad_anatomic_location_imaging_focus: Optional[Union[str, LoincPartId]] = (
-        None
-    )
+    primary_rad_anatomic_location_imaging_focus: Optional[
+        Union[str, LoincPartId]
+    ] = None
     primary_rad_anatomic_location_laterality: Optional[Union[str, LoincPartId]] = None
     primary_rad_anatomic_location_laterality_presence: Optional[
         Union[str, LoincPartId]
     ] = None
-    primary_rad_anatomic_location_region_imaged: Optional[Union[str, LoincPartId]] = (
-        None
-    )
+    primary_rad_anatomic_location_region_imaged: Optional[
+        Union[str, LoincPartId]
+    ] = None
     primary_rad_guidance_for_action: Optional[Union[str, LoincPartId]] = None
     primary_rad_guidance_for_approach: Optional[Union[str, LoincPartId]] = None
     primary_rad_guidance_for_object: Optional[Union[str, LoincPartId]] = None
@@ -950,9 +950,9 @@ slots.loincTerm__primary_property = Slot(
 )
 
 slots.loincTerm__primary_time_aspect = Slot(
-    uri=LOINC_PROPERTY.TIME_ASPECT,
+    uri=LOINC_PROPERTY.TIME_ASPCT,
     name="loincTerm__primary_time_aspect",
-    curie=LOINC_PROPERTY.curie("TIME_ASPECT"),
+    curie=LOINC_PROPERTY.curie("TIME_ASPCT"),
     model_uri=LOINC.loincTerm__primary_time_aspect,
     domain=None,
     range=Optional[Union[str, LoincPartId]],

--- a/src/comp_loinc/schema/comp_loinc.yaml
+++ b/src/comp_loinc/schema/comp_loinc.yaml
@@ -142,7 +142,7 @@ classes:
 
       # 3
       primary_time_aspect:
-        slot_uri: loinc_property:TIME_ASPECT
+        slot_uri: loinc_property:TIME_ASPCT
         multivalued: false
         range: LoincPart
         required: false

--- a/test/test.py
+++ b/test/test.py
@@ -117,7 +117,6 @@ class CompLoincTest(unittest.TestCase):
 
         todo: In cases where n props is 5 and not 6, check to ensure missing prop is as expected? If is always same
         todo: Consider test for rad- and document- model props
-        todo: If rename to TIME_ASPECT was unintentional and we undo, update here.
         """
         onto_filename = 'loinc-term-primary-def.owl'
         core_props = {
@@ -126,9 +125,7 @@ class CompLoincTest(unittest.TestCase):
             'http://loinc.org/property/SYSTEM',
             'http://loinc.org/property/SCALE_TYP',
             'http://loinc.org/property/METHOD_TYP',
-            # TIME_ASP(E)CT: 2024/10 w/out 'E' is how it is spelled in release. But we rename it.
             'http://loinc.org/property/TIME_ASPCT',
-            'http://loinc.org/property/TIME_ASPECT',
         }
         self._tests_common(onto_filename)
 


### PR DESCRIPTION
## Overview
Possibly because of character limit, the LOINC property `TIME_ASPCT` is missing an `E`. However we accidentally added the `E`. This PR changes it back.