### PR TITLE
Source version & build updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.idea/
 /docs/
+/documentation/stats-main.md
+/documentation/stats-dangling.md
 /project/docs/
 /tmp/
 /out*

--- a/README.md
+++ b/README.md
@@ -13,19 +13,29 @@ Computational LOINC (in OWL).
 3. Install [Poetry](https://python-poetry.org/): `pip install poetry`
 4. Install dependencies: `poetry install`
 5. Unzip downloaded inputs into the root directory of the repo.
-  - a. Core developers: Download latest `*-build-sources.zip` from [Google Drive](
-https://drive.google.com/drive/folders/1Ae5NX959S_CV60nbf9N_37Ao-wJzM0fh).
+  - a. Core developers: Download latest `*_comploinc-build-sources.zip` from [Google Drive](
+https://drive.google.com/drive/folders/1wguwYdsasYmKL_hSOqW0yeN7ICw4LgLV), where `*` is a date `YYYY-MM-DD`.
   - b. Everyone else: Download releases from each source:
-    - [LOINC](https://loinc.org/downloads/)
-    - [SNOMED](https://www.nlm.nih.gov/healthit/snomedct/us_edition.html)
-    - [LOINC-SNOMED Ontology](https://loincsnomed.org/downloads)
-    - [LOINC Tree](https://loinc.org/tree/)
-      - From this app, select from the "Hierarchy" menu at the top of the page. There are 7 options. When you select an 
-      option, select 'Export'. Extract the CSVs in each zip, and put them into a single folder, using the following 
-      names: `class.csv`, `component.csv`, `document.csv`, `method.csv`, `panel.csv`, `system.csv`, 
-      `component_by_system.csv`.
-    - General instructions: Ensure that these 4 sources are unzipped to the locations shown in 
-    [comploinc_config.yaml/](comploinc_config.yaml), or update the config to match your locations.
+    - Ensure that [comploinc_config.yaml/](comploinc_config.yaml) is updated to point to default to the 
+    versions of your choosing, and ensure the paths are correct. The config is customizable to whatever directory 
+    structure / folder names you choose, but below are some suggestions / conventions for each source.
+    - [LOINC](https://loinc.org/downloads/): Unzip and place the folder (named `Loinc_2.80` or 
+    similar) into a `loinc_release` folder in the root directory of the repo.
+    - [LOINC Tree](https://loinc.org/tree/): From this app, select from the "Hierarchy" menu at the top of the page. There are 7 options. 
+    When you select an option, select 'Export'. Extract the CSVs in each zip, and put them into a single folder, using 
+    the following names: `class.csv`, `component.csv`, `document.csv`, `method.csv`, `panel.csv`, `system.csv`, 
+    `component_by_system.csv`. The name of this folder should reflect the current version number of LOINC as it shows on
+    the [LOINC download page](https://loinc.org/downloads/). For example, if it says "2.80", on that page, the folder 
+    name should be "2.80". Place this folder into a `loinc_trees` folder in the root directory of the repo.
+    - [LOINC-SNOMED Ontology](https://loincsnomed.org/downloads): Go to the website and fill out a form. You will get an
+    email with a download link. Unzip this, and place the unzipped folder into another folder with the version number 
+    declared on that download page. Then place that folder into a `loinc_snomed_release` folder in the root directory 
+    of the repo.
+    - LOINC-SNOMED mappings: There is a mapping TSV file, e.g. `part-mappings_0.0.3.tsv`, which should be placed in the 
+    `loinc_snomed_release` directory at the root of the repo. However, this file is not downloadable online. To request 
+    it, find the contact email address in `pyproject.toml`, and email us with a request. 
+    - [SNOMED](https://www.nlm.nih.gov/healthit/snomedct/us_edition.html): Unzip and place the folder (named `SnomedCT_InternationalRF2_PRODUCTION_20240801T120000Z` or 
+    similar) into a `snomed_release` folder in the root directory of the repo.
 
 **Contingencies**
 Apple Silicon users may need to run `export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` before running 
@@ -34,8 +44,7 @@ Apple Silicon users may need to run `export PYTHON_KEYRING_BACKEND=keyring.backe
 ## Repository Structure
 * [data/](data/) - Static input files that don't need to be downloaded.
 * [logs/](logs/output) - Logs
-* [owl-files/](owl-files/) - Place the default build output files in this directory and then open the `comploinc.owl` 
- file in Protégé to get what is considered to be the default content of CompLOINC (still WIP).
+* [owl-files/](owl-files/) - Contains some files to be merged together with build outputs.
 * [src/comp_loinc/](src/comp_loinc) - Uses a loinclib `networkx` graph to generate ontological outputs.
   * [builds/](src/comp_loinc/builds) -- LinkML schema
   * [datamodel/](src/comp_loinc/datamodel) - generated Python LinkML datamodel
@@ -163,12 +172,20 @@ This directory is not committed. `/output/analysis/dangling/` has several files 
 
 ### Standard operating procedures (SOPs)
 #### Setting up new/updated inputs/sources
-1. Create a new `YYYY-MM-DD_comploinc-build-sources.zip` in the [Google Drive folder](
+When any of the sources (e.g. LOINC release, LOINC tree web app, LOINC-SNOMED ontology, SNOMED release) are updated, we 
+need to follow this procedure. 
+
+1. Download and unzip the source files into the desired / appropriate directories.
+2. Update the config to point to these new paths.
+3. Create a new `YYYY-MM-DD_comploinc-build-sources.zip` in the [Google Drive folder](
 https://drive.google.com/drive/folders/1Ae5NX959S_CV60nbf9N_37Ao-wJzM0fh). Ensure it has the correct structure (folder 
 names and files at the right paths).
-2. Make the link public: In the Google Drive folder, right-click the file, select "Share", and click "Share."  At the 
+4. Make the link public: In the Google Drive folder, right-click the file, select "Share", and click "Share."  At the 
 bottom, under "General Access", click the left dropdown and select "Anyone with the link."  Click "Copy link".
-3. Update `DL_LINK_ID` in GitHub: Go to the [page](https://github.com/loinc/comp-loinc/settings/secrets/actions/DL_LINK_ID) 
-for updating it. Paste the link from the previous step into the box, and click "Update secret."
+5. Update `DL_LINK_ID` in GitHub: Go to the [page](https://github.com/loinc/comp-loinc/settings/secrets/actions/DL_LINK_ID) 
+for updating it. Paste the link from the previous step into the box, and click "Update secret." The value of this should
+ be set to the ID found within the URL from step (4). E.g. if the link is "
+6. https://drive.google.com/file/d/1i9Ym1zJhC_l6P8egAMcj4Q1QtTGk7aST/view?usp=drive_link," the ID would be  
+`1i9Ym1zJhC_l6P8egAMcj4Q1QtTGk7aST`. 
 
 </details>

--- a/comploinc_config.yaml
+++ b/comploinc_config.yaml
@@ -1,6 +1,6 @@
 loinc:
   release:
-    default: '2.78'
+    default: '2.80'
     '2.67':
       version: '2.67'
       path: 'loinc_release/2.67' # runtime home directory-relative path
@@ -8,12 +8,18 @@ loinc:
       version:  '2.78'
       path: 'loinc_release/Loinc_2.78'
       classes: 'data/loinc_classes.csv'
+    '2.80':
+      version:  '2.80'
+      path: 'loinc_release/Loinc_2.80'
+      classes: 'data/loinc_classes.csv'
 
 loinc_tree:
   release:
-    default: '2.78'
+    default: '2.80'
     '2.78':
-      tree_path: 'loinc_trees/2024-08-31'
+      tree_path: 'loinc_trees/2.78'
+    '2.80':
+      tree_path: 'loinc_trees/2.80'
 
 loinc_nlp_tree:
   similarity_threshold: 0.5
@@ -29,12 +35,18 @@ snomed:
 
 loinc_snomed:
   release:
-    default: '20231015'
+    default: '1.0'
     '20231015':
       files:
-        description: 'loinc_snomed_release/Snapshot/Terminology/xsct2_Description_Snapshot-en_LO1010000_20231015.txt'
-        identifier: 'loinc_snomed_release/Snapshot/Terminology/xsct2_Identifier_Snapshot_LO1010000_20231015.txt'
-        relationship: 'loinc_snomed_release/Snapshot/Terminology/xsct2_Relationship_Snapshot_LO1010000_20231015.txt'
+        description: 'loinc_snomed_release/20231015/Snapshot/Terminology/xsct2_Description_Snapshot-en_LO1010000_20231015.txt'
+        identifier: 'loinc_snomed_release/20231015/Snapshot/Terminology/xsct2_Identifier_Snapshot_LO1010000_20231015.txt'
+        relationship: 'loinc_snomed_release/20231015/Snapshot/Terminology/xsct2_Relationship_Snapshot_LO1010000_20231015.txt'
+        part_mapping: 'loinc_snomed_release/part-mappings_0.0.3.tsv'
+    '1.0':
+      files:
+        description: 'loinc_snomed_release/1.0/SnomedCT_LOINCExtension_PRODUCTION_LO1010000_20250321T120000Z/Snapshot/Terminology/sct2_Description_Snapshot-en_LO1010000_20250321.txt'
+        identifier: 'loinc_snomed_release/1.0/SnomedCT_LOINCExtension_PRODUCTION_LO1010000_20250321T120000Z/Snapshot/Terminology/sct2_Identifier_Snapshot_LO1010000_20250321.txt'
+        relationship: 'loinc_snomed_release/1.0/SnomedCT_LOINCExtension_PRODUCTION_LO1010000_20250321T120000Z/Snapshot/Terminology/sct2_Relationship_Snapshot_LO1010000_20250321.txt'
         part_mapping: 'loinc_snomed_release/part-mappings_0.0.3.tsv'
 
 prop_use:

--- a/documentation/stats.md
+++ b/documentation/stats.md
@@ -9,10 +9,10 @@
 | Metric | Value |
 | ------ | ----- |
 | Annotation properties | 13 |
-| Axioms | 2274506 |
-| Logical axioms | 1072609 |
-| Classes | 241520 |
-| Object properties | 56 |
+| Axioms | 2171244 |
+| Logical axioms | 965973 |
+| Classes | 241874 |
+| Object properties | 57 |
 | Data properties | 0 |
 | Individuals | 0 |
 
@@ -32,33 +32,33 @@
 
 | Metric | Value |
 | ------ | ----- |
-| AnnotationAssertion | 960310 |
-| EquivalentClasses | 217226 |
+| AnnotationAssertion | 963329 |
+| EquivalentClasses | 218286 |
 | SubObjectPropertyOf | 55 |
-| Declaration | 241587 |
-| SubClassOf | 855328 |
+| Declaration | 241942 |
+| SubClassOf | 747632 |
 
 
 #### Entity namespaces: axiom counts by namespace
 
 | Metric | Value |
 | ------ | ----- |
-| prefix_unknown | 59 |
+| prefix_unknown | 58 |
 | owl | 1 |
 | rdf | 1 |
 | LOINC_PART_GRP_CMP | 2462 |
 | LOINC_PART_GRP_SYS | 1697 |
 | rdfs | 1 |
-| LOINC_PART | 116360 |
+| LOINC_PART | 116185 |
 | LOINC_PART_GRP_CMP_SYS | 18116 |
-| LOINC_TERM | 102893 |
+| LOINC_TERM | 103424 |
 
 
 #### Class expressions used
 
 | Metric | Value |
 | ------ | ----- |
-| Class | 3558892 |
-| ObjectSomeValuesFrom | 1475564 |
-| ObjectIntersectionOf | 206980 |
+| Class | 3383067 |
+| ObjectSomeValuesFrom | 1515211 |
+| ObjectIntersectionOf | 208040 |
 

--- a/owl-files/comploinc-default/catalog-v001.xml
+++ b/owl-files/comploinc-default/catalog-v001.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="https://comploinc-query-examples" uri="comploinc-query-examples.owl"/>
+
     <uri id="Imports Wizard Entry" name="https://comploinc-axioms" uri="comploinc-axioms.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc-manual" uri="comploinc-manual.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc/snomed-parts" uri="snomed-parts.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-terms-list-all" uri="loinc-terms-list-all.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-term-supplementary-def" uri="loinc-term-supplementary-def.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-term-primary-def" uri="loinc-term-primary-def.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-snomed-equiv" uri="loinc-snomed-equiv.owl"/>
-    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-part-list-all" uri="loinc-part-list-all.owl"/>
     <uri id="Imports Wizard Entry" name="https://comploinc/loinc-part-hierarchy-all" uri="loinc-part-hierarchy-all.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-part-list-all" uri="loinc-part-list-all.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-terms-list-all" uri="loinc-terms-list-all.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-term-primary-def" uri="loinc-term-primary-def.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-term-supplementary-def" uri="loinc-term-supplementary-def.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/snomed-parts" uri="snomed-parts.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/loinc-snomed-equiv" uri="loinc-snomed-equiv.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/group_components" uri="group_components.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/group_systems" uri="group_systems.owl"/>
+    <uri id="Imports Wizard Entry" name="https://comploinc/group_components_systems" uri="group_components_systems.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/owl-files/comploinc-default/comploinc.owl
+++ b/owl-files/comploinc-default/comploinc.owl
@@ -8,13 +8,15 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 Ontology(<https://comploinc>
 Import(<https://comploinc-axioms>)
-Import(<https://comploinc-query-examples>)
 Import(<https://comploinc/loinc-part-hierarchy-all>)
 Import(<https://comploinc/loinc-part-list-all>)
-Import(<https://comploinc/loinc-snomed-equiv>)
+Import(<https://comploinc/loinc-terms-list-all>)
 Import(<https://comploinc/loinc-term-primary-def>)
 Import(<https://comploinc/loinc-term-supplementary-def>)
-Import(<https://comploinc/loinc-terms-list-all>)
 Import(<https://comploinc/snomed-parts>)
+Import(<https://comploinc/loinc-snomed-equiv>)
+Import(<https://comploinc/group_components>)
+Import(<https://comploinc/group_systems>)
+Import(<https://comploinc/group_components_systems>)
 
 )

--- a/src/loinclib/loinc_tree_loader.py
+++ b/src/loinclib/loinc_tree_loader.py
@@ -91,7 +91,7 @@ class LoincTreeLoader:
             df[col] = df[col].str.replace("https://loinc.org/", "")  # URI to code
 
         # Add to hierarchy
-        similarity_threshold: float = self.config.config['loinc_nlp_tree'].get(
+        similarity_threshold: float = self.config.config["loinc_nlp_tree"].get(
             "similarity_threshold", default_similarity_threshold)
         for tpl in df.itertuples():
             # @formatter:off

--- a/test/test.py
+++ b/test/test.py
@@ -100,7 +100,7 @@ class CompLoincTest(unittest.TestCase):
         expected = {
             'https://loinc.org/LTC___Claims_attachments': 4,
             'https://loinc.org/LTC___Clinical': 1459,
-            'https://loinc.org/LTC___Laboratory': 3031,
+            'https://loinc.org/LTC___Laboratory': 3017,
             'https://loinc.org/LTC___Surveys': 451
         }
         for branch, count in branch_desc_counts.items():


### PR DESCRIPTION
Source version updates
- Updated paths for new release data for:
  - LOINC tree browser (also updated subfolder to version number rather than date). Also there is a new version.
  - LOINC: New version 2.8
  - LOINC-SNOMED ontology: New version 1.0
- Updated documentation concerning download and configuration of sources.
- Updated tests to expect results consistent with new sources.

Makefile updates
- Updated so that the full build now runs as a result of make all. Ensured all outputs and the whole dependency tree is accounted for.
- Updated catalog-v001.xml and comploinc.owl to also import grouping classes files.

Dangling parts statistics
- WIP. Will not be completed in this PR.