### PR TITLE
Stats updates: Namespaces & template

### DIFF
--- a/documentation/stats.md
+++ b/documentation/stats.md
@@ -39,19 +39,37 @@
 | SubClassOf | 747632 |
 
 
-#### Entity namespaces: axiom counts by namespace
+#### Entity namespaces counts
 
 | Metric | Value |
 | ------ | ----- |
-| prefix_unknown | 58 |
 | owl | 1 |
 | rdf | 1 |
 | LOINC_PART_GRP_CMP | 2462 |
 | LOINC_PART_GRP_SYS | 1697 |
+| SNOMED | 1 |
 | rdfs | 1 |
 | LOINC_PART | 116185 |
+| LOINC_PROP | 48 |
 | LOINC_PART_GRP_CMP_SYS | 18116 |
 | LOINC_TERM | 103424 |
+| COMPLOINC_AXIOM | 9 |
+
+
+#### Axiom namespaces counts
+
+| Metric | Value |
+| ------ | ----- |
+| owl | 1020 |
+| LOINC_PART_GRP_CMP | 24720 |
+| LOINC_PART_GRP_SYS | 38643 |
+| rdfs | 241867 |
+| SNOMED | 5890 |
+| LOINC_PROP | 1440019 |
+| LOINC_PART | 1808312 |
+| LOINC_PART_GRP_CMP_SYS | 335370 |
+| LOINC_TERM | 1890586 |
+| COMPLOINC_AXIOM | 72 |
 
 
 #### Class expressions used

--- a/makefile
+++ b/makefile
@@ -74,7 +74,7 @@ static-merge-files: $(STATIC_MERGE_FILES)
 
 merge: $(DEFAULT_BUILD_DIR)/merged-and-reasoned/comploinc-merged-unreasoned.owl
 
-# todo: Delete this file after the reasoned one has been created?
+# todo: Delete this file after the reasoned one has been created? or move it to tmp/?
 $(DEFAULT_BUILD_DIR)/merged-and-reasoned/comploinc-merged-unreasoned.owl: $(STATIC_MERGE_FILES) $(MODULE_FILES) $(GROUPING_FILES)
 	robot merge $(patsubst %, --input %, $(wildcard $(DEFAULT_BUILD_DIR)/*.owl)) --output $@
 
@@ -87,11 +87,15 @@ merge-reason: static-merge-files merge reason
 
 # Analysis / Stats  ----------------------------------------------------------------------------------------------------
 SOURCE_METRICS_TEMPLATE=src/comp_loinc/analysis/stats.md.j2
-PREFIXES_METRICS=--prefix 'LOINC_PART: https://loinc.org/LP' \
+PREFIXES_METRICS=\
+	--prefix 'LOINC_PART: https://loinc.org/LP' \
 	--prefix 'LOINC_TERM: https://loinc.org/' \
 	--prefix 'LOINC_PART_GRP_CMP: http://comploinc//group/component/LP' \
 	--prefix 'LOINC_PART_GRP_SYS: http://comploinc//group/system/LP' \
 	--prefix 'LOINC_PART_GRP_CMP_SYS: http://comploinc//group/component-system/LP' \
+	--prefix 'LOINC_PROP: http://loinc.org/property/' \
+	--prefix 'COMPLOINC_AXIOM: https://comploinc-axioms\#' \
+	--prefix 'SNOMED: http://snomed.info/'
 
 input/analysis/:
 	mkdir -p $@

--- a/src/comp_loinc/analysis/stats.md.j2
+++ b/src/comp_loinc/analysis/stats.md.j2
@@ -36,11 +36,18 @@
 {% for key, value in metrics.axiom_type_count_incl.items() %}| {{ key }} | {{ value }} |
 {% endfor %}
 
-#### Entity namespaces: axiom counts by namespace
+#### Entity namespaces counts
 
 | Metric | Value |
 | ------ | ----- |
 {% for key, value in metrics.namespace_entity_count.items() %}| {{ key }} | {{ value }} |
+{% endfor %}
+
+#### Axiom namespaces counts
+
+| Metric | Value |
+| ------ | ----- |
+{% for key, value in metrics.namespace_axiom_count.items() %}| {{ key }} | {{ value }} |
 {% endfor %}
 
 #### Class expressions used


### PR DESCRIPTION
Stats updates
- Bug fix: Entity counts were ambiguous; could be confused with axiom counts.
- Add: Axiom counts, by namespace
- Update: Stats prefix maps
- Data quality: Unknown prefixes are now gone from stats. All prefixes accounted for.
- Update: Stats jinja template